### PR TITLE
remove codesponsor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ## Proxy Object Observe
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/ygkcNhfZ9nTDeVM6P8LSGn1C/keithamus/proxy-object-observe'>  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/ygkcNhfZ9nTDeVM6P8LSGn1C/keithamus/proxy-object-observe.svg' /></a>
+
 
 This super simple library uses ES6 Proxies to provide an API similar to the now deprecated Object.observe spec.
 


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8